### PR TITLE
Add clarification for sort order

### DIFF
--- a/docs/using/search.md
+++ b/docs/using/search.md
@@ -73,3 +73,8 @@ By default all search results in Omnivore are sorted by saved date. This puts th
 - `sort:saved`: Sort by saved date
 - `sort:updated`: Sort by time the item was updated, for example having a label or highlight added
 - `sort:score`: Sort by query term relevance
+
+Additionally, you can change the sort order by apending either `-asc` or `-des` to the sort parameter to sort by ascending or descending order respectively:
+
+- `sort:saved-asc`: Sort by saved date in Ascending order (oldest to newest saved date)
+- `sort:updated-des`: Sort by time the item was updated, in descending order (newest to oldest)


### PR DESCRIPTION
Adding some clarifying language about how the sort works, specifically about how to change the order to ascending when presenting results.

According to this line [1], the sort order is only looking for `asc` and just assumes descending otherwise. I wrote the docs in a way to be explicit with the descending order, only to make it easier to understand. If you prefer we only make a documentation change that explicitly reflects the `asc` option, I'm happy to refactor.


[1]: https://github.com/omnivore-app/omnivore/blob/1cabdde6797e37da7f44e726b83d3f95d8b6bbcc/packages/api/src/utils/search.ts#L189